### PR TITLE
Feat/refreshtoken blacklist

### DIFF
--- a/backend/src/main/java/com/ktnu/AiLectureSummary/config/CookieProperties.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/config/CookieProperties.java
@@ -16,4 +16,8 @@ public class CookieProperties {
 
     @Pattern(regexp = "^(None|Lax|Strict)$", message = "SameSite must be None, Lax, or Strict")
     private String sameSite;
+
+    private long accessTokenExpiry;
+    private long refreshTokenExpiry;
+
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/config/JwtProperties.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/config/JwtProperties.java
@@ -19,4 +19,6 @@ public class JwtProperties {
 
 //    @Min(value=60000,message = "JWT expiration should be at least 60000ms (1 minute)") //Spring이 자꾸 String으로 환경변수를 읽어서 주석처리
     private long expiration;
+
+    private long refreshExpiration;
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/config/RedisConfig.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/config/RedisConfig.java
@@ -20,11 +20,13 @@ public class RedisConfig {
     /**
      * Redis에서 다양한 자료형(Object)을 다룰 수 있도록 설정된 일반적인 RedisTemplate Bean입니다.
      * 복잡한 객체 직렬화 및 다양한 Redis 자료구조(Hash, List 등) 작업에 사용됩니다.
+     *
+     * 필요하면 주석 해제 후 사용 예정
      */
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        return template;
-    }
+//    @Bean
+//    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+//        RedisTemplate<String, Object> template = new RedisTemplate<>();
+//        template.setConnectionFactory(connectionFactory);
+//        return template;
+//    }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/config/SecurityConfig.java
@@ -33,10 +33,10 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())  // API 서버는 보통 CSRF 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // httponly 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/register", "/health",
-                                "/v3/api-docs/**","/api/password/verify","/api/password/reset",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html").permitAll() // 로그인, 회원가입, 스웨거, 헬스체크, 비밀번호 변경 인증없이 접근 허용
+                        .requestMatchers("/api/auth/login", "/api/auth/register","/api/auth/refresh", //로그인 관련
+                                "/api/password/verify","/api/password/reset", // 비밀번호 재설정 관련
+                                "/health", "/swagger-ui/**","/v3/api-docs/**", // swagger & health check
+                                "/swagger-ui.html").permitAll() // 로그인, 회원가입, 스웨거, 헬스체크, 비밀번호 변경 등 인증없이 접근 허용
 //                        .requestMatchers(HttpMethod.GET, "/api/Lecture/**").permitAll()
                         .anyRequest().authenticated() // 그 외 요청은 인증 필요
                 )

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/AuthController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/AuthController.java
@@ -6,7 +6,9 @@ import com.ktnu.AiLectureSummary.dto.member.MemberLoginRequest;
 import com.ktnu.AiLectureSummary.dto.member.MemberLoginResponse;
 import com.ktnu.AiLectureSummary.dto.member.MemberRegisterRequest;
 import com.ktnu.AiLectureSummary.service.MemberAuthService;
+import com.ktnu.AiLectureSummary.util.CookieResponseUtil;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +28,6 @@ public class AuthController {
     private final CookieProperties cookieProperties;
 
 
-
     @PostMapping("/register")
     @Operation(summary = "회원가입", description = "사용자 정보를 입력받아 이메일 중복 체크후 회원가입")
     public ResponseEntity<ApiResponse<Void>> register(@Valid @RequestBody MemberRegisterRequest request) {
@@ -37,21 +38,21 @@ public class AuthController {
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "사용자 정보를 입력 받아 로그인 시도 성공시 jwt(httponly) 반환")
     public ResponseEntity<ApiResponse<MemberLoginResponse>> login(@Valid @RequestBody MemberLoginRequest request, HttpServletResponse response) { // HttpServletResponse response는 응답 헤더, 쿠키를 직접 조작할수 있게 하기 위해 사용됨
-        // 로그인 처리 시도 (memberService에서 인증 처리 + JWT 발급)
+        // 로그인 처리 시도 (memberAuthService에서 인증 처리 + JWT 발급)
         MemberLoginResponse result = memberAuthService.login(request);
 
-        // 발급된 JWT를 Httponly 쿠키에 담아 응답 헤더에 추가
-        ResponseCookie cookie = ResponseCookie.from("token", result.getAccessToken())
-                .httpOnly(cookieProperties.isHttpOnly())
-                .path("/")
-                .sameSite(cookieProperties.getSameSite()) // CSRF 방어엔 Lax 이상 권장, 배포시 도메인 분리로 None 사용 예정
-                .secure(cookieProperties.isSecure()) // https 에서만 전송 // 개발 환경 false
-                .maxAge(3600) // JWT 만료 시간과 일치시킬 것 (쿠키 만료시 자동 삭제)
-                .build();
+        // AccessToken & RefreshToken 쿠키 설정
+        ResponseCookie accessCookie = CookieResponseUtil.buildAccessTokenCookie(result.getAccessToken(), cookieProperties);
+        ResponseCookie refreshCookie = CookieResponseUtil.buildRefreshTokenCookie(result.getRefreshToken(), cookieProperties);
 
-        response.addHeader("Set-Cookie", cookie.toString());
+//        HTTP/1.1 200 OK
+//        Set-Cookie: token=ACCESS_TOKEN_VALUE; Path=/; HttpOnly; Secure; SameSite=Lax
+//        Set-Cookie: refresh_token=REFRESH_TOKEN_VALUE; Path=/; HttpOnly; Secure; SameSite=Lax
 
-        return ResponseEntity.status(200).header("Set-Cookie", cookie.toString()).body(ApiResponse.success("로그인 성공", result));
+        return ResponseEntity.status(200)
+                .header("Set-Cookie", accessCookie.toString())
+                .header("Set-Cookie", refreshCookie.toString())
+                .body(ApiResponse.success("로그인 성공", result)); // JWT는 모두 쿠키(HttpOnly)로 전송되며, 바디의 토큰 정보는 프론트에서 사용되지 않음 (개발 편의를 위해 포함함)
     }
 
 
@@ -64,20 +65,32 @@ public class AuthController {
      */
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "jwt를 덮어씌움 만료시간 0초로 설정 (기존에 토큰은 제대로 삭제되는게 아니라 보완 필요(blacklist, refreshtoken 등)")
-    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
-        // 즉시 만료되는 JWT를 생성
-        ResponseCookie expiredCookie = ResponseCookie.from("token", "")
-                .httpOnly(cookieProperties.isHttpOnly())
-                .secure(cookieProperties.isSecure()) // https 환경 대응
-                .path("/")
-                .maxAge(0) // 즉시 만료
-                .sameSite(cookieProperties.getSameSite()) //
-                .build();
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request, HttpServletResponse response) {
 
-        // TODO (refreshtoken 또는 blacklist 추가 예정)
+        ResponseCookie expiredCookie = CookieResponseUtil.expireAccessTokenCookie(cookieProperties);
+        ResponseCookie expiredRefreshCookie = CookieResponseUtil.expireRefreshTokenCookie(cookieProperties);
+
         // 덮어 씌우는 방식으로 로그아웃처리
         response.addHeader("Set-Cookie", expiredCookie.toString());
+        response.addHeader("Set-Cookie", expiredRefreshCookie.toString());
+
+        // blacklist 등록 및 refreshToken을 redis에서 삭제
+        memberAuthService.logout(request);
 
         return ResponseEntity.ok(ApiResponse.success("로그아웃 완료", null));
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "AccessToken 재발급", description = "로그인 후 사용중 흐름이 끊기지 않도록 refreshToken 사용")
+    public ResponseEntity<ApiResponse<Void>> refresh(HttpServletRequest request, HttpServletResponse response) {
+        // refreshtoken 유효성 검사 & accesstoken 재발급
+        String newAccessToken = memberAuthService.reissueAccessToken(request);
+
+        // access_token 쿠키 설정
+        ResponseCookie accessCookie = CookieResponseUtil.buildAccessTokenCookie(newAccessToken, cookieProperties);
+
+        return ResponseEntity.ok()
+                .header("Set-Cookie", accessCookie.toString())
+                .body(ApiResponse.success("AccessToken 재발급", null));
     }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/ProfileController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/ProfileController.java
@@ -39,7 +39,7 @@ public class ProfileController {
         MemberEditResponse memberEditResponse = memberProfileService.editProfile(userDetails, request);
         // 비밀번호 변경으로 토큰 재발급한 경우
         if (memberEditResponse.getToken() != null) {
-            ResponseCookie cookie = ResponseCookie.from("token", memberEditResponse.getToken())
+            ResponseCookie cookie = ResponseCookie.from("access_token", memberEditResponse.getToken())
                     .httpOnly(cookieProperties.isHttpOnly())
                     .secure(cookieProperties.isSecure())
                     .path("/")

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/member/MemberLoginResponse.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/member/MemberLoginResponse.java
@@ -7,4 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MemberLoginResponse {
     private String accessToken;
+    private String refreshToken;
+
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/memberLecture/MemberLectureListItemResponse.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/memberLecture/MemberLectureListItemResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 
 @AllArgsConstructor
 @Getter
@@ -27,9 +28,12 @@ public class MemberLectureListItemResponse {
                         memberLecture.getCustomTitle(),
                         memberLecture.getLecture().getDuration(),
                         memberLecture.getEnrolledAt(),
-                        Base64.getEncoder().encodeToString(memberLecture.getLecture().getThumbnail())
-
+                        encodeThumbnailSafe(memberLecture.getLecture().getThumbnail())
                 ))
                 .toList();
+    }
+
+    public static String encodeThumbnailSafe(byte[] thumbnail) {
+        return thumbnail != null ? Base64.getEncoder().encodeToString(thumbnail) : null;
     }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/security/JwtAuthenticationFilter.java
@@ -1,8 +1,8 @@
 package com.ktnu.AiLectureSummary.security;
 
+import com.ktnu.AiLectureSummary.util.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 
 @Component
@@ -30,36 +29,35 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         // 쿠키에서 JWT 추출
-        String token = resolveToken(request);
-
+        String token = CookieUtil.getCookieValue(request, "token").orElse(null);
         // 토큰이 존재하고, 유효한 경우
         if (token != null) {
-                if (jwtProvider.validateToken(token)) {
-                    // 토큰에서 사용자 ID 추출
-                    Long userId = jwtProvider.getUserIdFromToken(token);
+            if (jwtProvider.validateAccessToken(token)) {
+                // 토큰에서 사용자 ID 추출
+                Long userId = jwtProvider.getUserIdFromAccessToken(token);
 
-                    // 해당 ID로 사용자 정보 조회
-                    CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserById(userId);
+                // 해당 ID로 사용자 정보 조회
+                CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserById(userId);
 
-                    // 사용자 정보가 없는 경우 인증 실패 처리
-                    if (userDetails == null) {
-                        return;
-                    }
-
-                    // 인증 객체 생성 (사용자 정보 + 권한)
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(
-                                    userDetails, // 사용자 정보
-                                    null, // 비밀번호, 자격증명용 (JWT로 사용자 인증이 끝났기에 null)
-                                    userDetails.getAuthorities() // 권한
-                            );
-                    // 요청 정보 기반으로 인증 디테일 설정(부가 기능)
-                    // 인증객체에 추가적인 정보 (클라이언트 IP, 세션 ID 등)를 담음 -> 로깅, 감사, 트래픽 분석에 사용됨
-                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                    // 현재 요청에 대해 인증 정보 등록 (SecurityContext에 저장됨)
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                // 사용자 정보가 없는 경우 인증 실패 처리
+                if (userDetails == null) {
+                    return;
                 }
+
+                // 인증 객체 생성 (사용자 정보 + 권한)
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails, // 사용자 정보
+                                null, // 비밀번호, 자격증명용 (JWT로 사용자 인증이 끝났기에 null)
+                                userDetails.getAuthorities() // 권한
+                        );
+                // 요청 정보 기반으로 인증 디테일 설정(부가 기능)
+                // 인증객체에 추가적인 정보 (클라이언트 IP, 세션 ID 등)를 담음 -> 로깅, 감사, 트래픽 분석에 사용됨
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                // 현재 요청에 대해 인증 정보 등록 (SecurityContext에 저장됨)
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
 
         // 8. 인증 실패 또는 토큰이 없는 경우에도 필터는 통과시킴
@@ -67,20 +65,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    /**
-     * HttpServletRequest에서 JWT 토큰(cookie)을 추출 합니다.
-     *
-     * @param request
-     * @return
-     */
-    private String resolveToken(HttpServletRequest request) {
-        if (request.getCookies() != null) {
-            return Arrays.stream(request.getCookies())
-                    .filter(c -> c.getName().equals("token"))  // 쿠키 이름이 'token'인 것
-                    .findFirst()
-                    .map(Cookie::getValue) // Optional<Cookie> → Optional<String>
-                    .orElse(null);
-        }
-        return null;
-    }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/security/JwtAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         // 쿠키에서 JWT 추출
-        String token = CookieUtil.getCookieValue(request, "token").orElse(null);
+        String token = CookieUtil.getCookieValue(request, "access_token").orElse(null);
         // 토큰이 존재하고, 유효한 경우
         if (token != null) {
             if (jwtProvider.validateAccessToken(token)) {

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberProfileService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberProfileService.java
@@ -54,7 +54,7 @@ public class MemberProfileService {
         if (!passwordUnchanged) {
             String encoded = passwordEncoder.encode(newPassword);
             member.changePassword(encoded);
-            token = jwtProvider.createToken(member.getId());
+            token = jwtProvider.generateAccessToken(member.getId());
         }
 
         return MemberEditResponse.builder()

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/util/CookieResponseUtil.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/util/CookieResponseUtil.java
@@ -1,0 +1,93 @@
+package com.ktnu.AiLectureSummary.util;
+
+import com.ktnu.AiLectureSummary.config.CookieProperties;
+import org.springframework.http.ResponseCookie;
+
+public class CookieResponseUtil {
+
+    /**
+     * accessToken을 담은 httponly 쿠키를 생성합니다.
+     * 이 쿠키의 만료 시간은 JWT의 exp와는 무관하며,
+     * 쿠키 자체가 브라우저에 유지되는 시간(maxAge)만 설정합니다.
+     *
+     * @param accessToken 생성된 access token 문자열
+     * @param properties application.yml에서 정의한 쿠키 설정값
+     * @return 생성된 ResponseCookie 객체
+     */
+    public static ResponseCookie buildAccessTokenCookie(String accessToken, CookieProperties properties) {
+        return ResponseCookie.from("access_token", accessToken)
+                .httpOnly(properties.isHttpOnly()) // true: JS에서 접근 불가 (XSS 방어)
+                .path("/")                         // 루트 경로 이하 요청에 자동 포함
+                .sameSite(properties.getSameSite()) // CSRF 방지용. Lax 또는 None (OAuth 등)
+                .secure(properties.isSecure())     // HTTPS에서만 전송. 로컬 개발 시 false 가능
+                // 아래 주석 중 하나만 선택하여 사용:
+                // .maxAge(Duration.ofSeconds(properties.getAccessTokenExpiry())) // 지속 쿠키: JWT 유지 시간과 일치시키는 경우
+                // 세션 쿠키로 만들려면 .maxAge() 생략하거나 -1로 설정 (브라우저 종료 시 쿠키 삭제됨)
+                .build();
+    }
+
+    /**
+     * access_token 쿠키를 즉시 만료시킵니다.
+     * 기존 쿠키를 덮어씌우고 maxAge=0으로 설정하여 삭제합니다.
+     *
+     * 일반적으로 로그아웃 처리 시 사용되며,
+     * access_token이 Redis 블랙리스트에 등록된 경우
+     * 남은 유효시간 동안 서버에서도 거부됩니다.
+     *
+     * @param properties 쿠키 설정값 (application.yml 등에서 주입)
+     * @return 즉시 만료되는 access_token 쿠키
+     */
+    public static ResponseCookie expireAccessTokenCookie(CookieProperties properties) {
+        return ResponseCookie.from("access_token", "")
+                .httpOnly(properties.isHttpOnly())
+                .secure(properties.isSecure())
+                .path("/")
+                .sameSite(properties.getSameSite())
+                .maxAge(0)
+                .build();
+    }
+
+    /**
+     * refresh_token을 담은 HttpOnly 쿠키를 생성합니다.
+     * 이 쿠키는 보통 access token보다 더 긴 유효 기간을 가지며,
+     * 클라이언트에 저장되었다가 access token 재발급 요청 시 자동으로 전송됩니다.
+     *
+     * @param refreshToken
+     * @param properties
+     * @return
+     */
+    public static ResponseCookie buildRefreshTokenCookie(String refreshToken, CookieProperties properties) {
+        return ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(properties.isHttpOnly())
+                .path("/")
+                .sameSite(properties.getSameSite())
+                .secure(properties.isSecure())
+//                .maxAge(Duration.ofSeconds(properties.getRefreshTokenExpiry())) // 주석처리로 완전한 로그아웃으로 구현 //TODO: 세션 쿠키 + refresh token 탈취 테스트
+                .build();
+    }
+
+    /**
+     * Refresh_token 쿠키를 즉시 만료시킵니다.
+     * @param properties
+     * @return
+     */
+    public static ResponseCookie expireRefreshTokenCookie(CookieProperties properties) {
+        return ResponseCookie.from("refresh_token", "")
+                .httpOnly(properties.isHttpOnly())
+                .secure(properties.isSecure())
+                .path("/")
+                .sameSite(properties.getSameSite())
+                .maxAge(0)
+                .build();
+    }
+}
+
+// TODO: 세션 쿠키 + refresh token 탈취 테스트
+// 공격 시나리오
+//	1.	사용자는 access_token을 세션 쿠키로 받음 (브라우저 종료 시 삭제)
+//	2.	refresh_token은 지속 쿠키 (maxAge로 살아있음)
+//	3.	사용자가 로그아웃 버튼 없이 브라우저만 끔
+//	4.	공격자가 같은 PC에서 브라우저 열고 해당 사이트 접속
+//	5.	refresh_token이 자동으로 서버에 전송됨 (HttpOnly 쿠키)
+//	6.	서버는 이를 유효하다고 판단하고 새로운 access_token 발급
+//	7.	로그인 없이 공격자 계정에 접근 성공

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/util/CookieUtil.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/util/CookieUtil.java
@@ -1,0 +1,32 @@
+package com.ktnu.AiLectureSummary.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+
+public class CookieUtil {
+
+    /**
+     * 요청에서 특정 이름의 쿠키 값을 찾아 반환합니다.
+     *
+     * @param request
+     * @param name 찾고자 하는 쿠키 이름
+     * @return 해당 이름의 쿠키 값 (Optional로 감싸서 반환)
+     */
+    public static Optional<String> getCookieValue(HttpServletRequest request, String name) {
+        // 쿠키가 없는 경우 Option.empty() 반환
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+
+        // 요청의 쿠키 중 name과 일치하는 쿠키를 찾아 해당 값을 반환
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,6 +23,8 @@ spring:
     http-only: ${COOKIE_HTTP_ONLY}
     secure: ${COOKIE_SECURE}
     same-site: ${COOKIE_SAME_SITE}
+    access-token-expiry: 3600 # 1시간
+    refresh-token-expiry: 604800 # 7일
 
   data:
     redis:
@@ -33,7 +35,9 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  expiration: 3600000
+  expiration: 3600000 # Access Token: 1시간
+  refresh-expiration: 604800000 # Refresh Token: 7일 (ms 단위)
+#  refresh-expiration: ${JWT_REFRESH_EXPIRATION}
 #  expiration: ${JWT_EXPIRATION}
 
 


### PR DESCRIPTION
## feat
- refreshtoken 기능 추가
- blacklist 기능 추가

## fix
- NPE 발생시키는 썸네일 관련 코드 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for refresh tokens, enabling secure token renewal without requiring users to log in again.
  - Introduced a new endpoint for refreshing access tokens using refresh tokens stored in cookies.
  - Logout now securely invalidates both access and refresh tokens.

- **Improvements**
  - Enhanced cookie handling for authentication tokens, including separate cookies for access and refresh tokens.
  - Improved security by blacklisting tokens upon logout and checking blacklists during authentication.
  - Added explicit configuration for token expiration times.

- **Bug Fixes**
  - Corrected cookie naming for consistency after password changes.

- **Refactor**
  - Centralized cookie creation and expiration logic.
  - Improved handling and validation of authentication tokens throughout the application.

- **Tests**
  - Updated tests to reflect new token management and Redis integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->