### PR TITLE
feat(frontend): 강의 목록 리스트 형태 추가

### DIFF
--- a/frontend/src/app/accountedit/page.tsx
+++ b/frontend/src/app/accountedit/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Loader2 } from "lucide-react"
+import { toast } from "@/hooks/use-toast"
 
 import { PasswordInputWithCapsWarning } from "@/components/ui/password-input"
 
@@ -34,7 +35,10 @@ export default function AccountEditPage() {
 
     // 변경사항 없음 체크
     if (username === user?.name && password.trim() === "") {
-      alert("변경할 내용을 입력해주세요.")
+      toast({
+        variant: "destructive",
+        description: "변경할 내용을 입력해주세요.",
+      })
       setIsLoading(false)
       return
     }
@@ -63,7 +67,12 @@ export default function AccountEditPage() {
         }),
       })
 
-      if (!res.ok) throw new Error("수정 실패")
+      if (!res.ok) {
+        toast({
+          variant: "destructive",
+          description: "변경할 내용을 입력해주세요.",
+        })
+      }
 
       alert("계정 정보가 수정되었습니다.")
       router.push("/dashboard")

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,15 +5,14 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Clock, FileText, Upload } from "lucide-react"
+import { Clock, FileText, Upload, LayoutGrid, List } from "lucide-react"
 import Link from "next/link"
-import Image from "next/image"
 import axios from "axios"
 import LectureCard from "@/components/lecture-card";
+import LectureList from "@/components/lecture-list"
 import { toast } from "@/hooks/use-toast"
 import {
   Dialog,
-  DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -22,15 +21,14 @@ import {
 
 
 axios.defaults.withCredentials = true;
+
 type Lecture = {
   lectureId: number;
   customTitle: string;
   title: string,
-  createdAt: string;
   duration: number;
   thumbnailUrl?: string;
-  email: string;
-  username: string;
+  enrolloedAt?: string,
 };
 
 type User = {
@@ -43,6 +41,15 @@ const formatDuration = (duration: number): string => {
   const secs = duration % 60;
   return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+const formatDate = (isoString: string): string => {
+  const date = new Date(isoString)
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  })
+}
 
 export default function DashboardPage() {
   // 로그인한 사용자 정보를 저장하는 상태
@@ -57,6 +64,7 @@ export default function DashboardPage() {
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [targetLecture, setTargetLecture] = useState<Lecture | null>(null);
+  const [viewMode, setViewMode] = useState<"card" | "list">("card")
 
 
   useEffect(() => {
@@ -171,11 +179,11 @@ export default function DashboardPage() {
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
           <div>
             <h1 className="text-3xl font-bold tracking-tight mb-1">마이 페이지</h1>
-            <p className="text-muted-foreground">요약한 동영상 목록과 계정 정보를 관리하세요</p>
+            <p className="text-muted-foreground">요약한 강의 목록과 계정 정보를 관리하세요</p>
           </div>
           <Link href="/">
             <Button className="gap-2">
-              <Upload size={16} />새 동영상 요약하기
+              <Upload size={16} />새 강의 요약하기
             </Button>
           </Link>
         </div>
@@ -187,7 +195,7 @@ export default function DashboardPage() {
                 <FileText className="h-10 w-10 text-primary" />
               </div>
               <h3 className="text-2xl font-bold mb-1">{lectures.length}</h3>
-              <p className="text-sm text-muted-foreground">요약한 동영상</p>
+              <p className="text-sm text-muted-foreground">요약한 강의</p>
             </CardContent>
           </Card>
 
@@ -226,6 +234,23 @@ export default function DashboardPage() {
           </Card>
         </div>
 
+        <div className="flex justify-end mb-4 gap-2">
+          <Button
+            variant={viewMode === "card" ? "default" : "outline"}
+            onClick={() => setViewMode("card")}
+            size="sm"
+          >
+            <LayoutGrid className="w-4 h-4 mr-1" /> 카드
+          </Button>
+          <Button
+            variant={viewMode === "list" ? "default" : "outline"}
+            onClick={() => setViewMode("list")}
+            size="sm"
+          >
+            <List className="w-4 h-4 mr-1" /> 리스트
+          </Button>
+        </div>
+
         <Tabs defaultValue="recent" className="mb-12">
           <TabsList className="grid w-full grid-cols-2 max-w-[400px]">
             <TabsTrigger value="recent">최근 요약</TabsTrigger>
@@ -233,35 +258,60 @@ export default function DashboardPage() {
           </TabsList>
 
           {/* 최근 요약 */}
-          <TabsContent value="recent" className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <TabsContent value="recent" className="mt-6">
             {lectures.length > 0 ? (
-              lectures.slice(0, 2).map((lecture: any) => (
-                <LectureCard
-                  key={lecture.lectureId}
-                  lecture={lecture}
-                  onDelete={() => openDeleteDialog(lecture)}
+              viewMode === "card" ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {lectures.slice(0, 2).map((lecture : any) => (
+                    <LectureCard
+                      key={lecture.lectureId}
+                      lecture={lecture}
+                      onDelete={() => openDeleteDialog(lecture)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <LectureList
+                  lectures={lectures.slice(0, 2)}
+                  onDelete={(id) => {
+                    const lecture = lectures.find((l) => l.lectureId === id);
+                    if (lecture) openDeleteDialog(lecture);
+                  }}
                 />
-              ))
+              )
             ) : (
-              <p className="text-muted-foreground text-center col-span-full">요약한 동영상이 없습니다.</p>
+              <p className="text-muted-foreground text-center">요약한 동영상이 없습니다.</p>
             )}
           </TabsContent>
 
           {/* 모든 요약 */}
-          <TabsContent value="all" className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <TabsContent value="all" className="mt-6">
             {lectures.length > 0 ? (
-              lectures.map((lecture: any) => (
-                <LectureCard
-                  key={lecture.lectureId}
-                  lecture={lecture}
-                  onDelete={() => openDeleteDialog(lecture)}
+              viewMode === "card" ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {lectures.map((lecture : any) => (
+                    <LectureCard
+                      key={lecture.lectureId}
+                      lecture={lecture}
+                      onDelete={() => openDeleteDialog(lecture)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <LectureList
+                  lectures={lectures}
+                  onDelete={(id) => {
+                    const lecture = lectures.find((l) => l.lectureId === id);
+                    if (lecture) openDeleteDialog(lecture);
+                  }}
                 />
-              ))
+              )
             ) : (
-              <p className="text-muted-foreground text-center col-span-full">요약한 동영상이 없습니다.</p>
+              <p className="text-muted-foreground text-center">요약한 동영상이 없습니다.</p>
             )}
           </TabsContent>
         </Tabs>
+
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <DialogContent>
             <DialogHeader>

--- a/frontend/src/components/UploadTabs.tsx
+++ b/frontend/src/components/UploadTabs.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Upload } from "lucide-react";
@@ -45,6 +44,7 @@ export default function UploadTabs() {
       }
 
       const lectureId = data.data.id;
+      localStorage.setItem(`lecture-type-${lectureId}`, "youtube");
       router.push(`/summary/${lectureId}`);
     } catch (error: any) {
       toast({
@@ -98,6 +98,7 @@ export default function UploadTabs() {
       });
 
       const lectureId = response.data.id;
+      localStorage.setItem(`lecture-type-${lectureId}`, "audio");
       router.push(`/summary/${lectureId}`);
     }
     catch (error: any) {
@@ -119,7 +120,7 @@ export default function UploadTabs() {
     <Tabs defaultValue="video" className="w-full">
       <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="video">영상 파일</TabsTrigger>
-        <TabsTrigger value="audio">녹음 파일</TabsTrigger>
+        <TabsTrigger value="audio">음성 파일</TabsTrigger>
         <TabsTrigger value="youtube">YouTube 링크</TabsTrigger>
       </TabsList>
 
@@ -211,13 +212,23 @@ export default function UploadTabs() {
           />
         </div>
         {youtubeUrl && (
-          <div className="mt-4">
-            <Button
-              onClick={handleYouTubeSubmit}
-              className="w-full flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 border-0 text-white"
-            >
-              <Upload size={16} /> 요약 시작
-            </Button>
+          <div className="mt-4 space-y-2">
+            {uploading ? (
+              <>
+                <Progress value={progress} className="h-2 rounded-full" />
+                <div className="flex justify-between text-xs text-muted-foreground">
+                  <span>업로드 진행률: {progress}%</span>
+                  <span>{progress === 100 ? "요약 생성 중..." : "업로드 중"}</span>
+                </div>
+              </>
+            ) : (
+              <Button
+                onClick={handleYouTubeSubmit}
+                className="w-full flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 border-0 text-white"
+              >
+                <Upload size={16} /> 요약 시작
+              </Button>
+            )}
           </div>
         )}
       </TabsContent>

--- a/frontend/src/components/lecture-card.tsx
+++ b/frontend/src/components/lecture-card.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 interface Lecture {
     lectureId: number;
     customTitle: string;
-    duration: string;
+    duration: number;
     thumbnailBase64?: string;
     enrolledAt: string;
 }
@@ -18,12 +18,11 @@ interface LectureCardProps {
     onDelete?: (id: number) => void;
 }
 
+
 export default function LectureCard({ lecture, onDelete }: LectureCardProps) {
-    const formatDuration = (duration: string): string => {
-        const seconds = parseInt(duration, 10);
-        if (isNaN(seconds)) return duration;
-        const mins = Math.floor(seconds / 60);
-        const secs = seconds % 60;
+    const formatDuration = (duration: number): string => {
+        const mins = Math.floor(duration / 60);
+        const secs = duration % 60;
         return `${mins}:${secs.toString().padStart(2, "0")}`;
     };
 
@@ -36,9 +35,23 @@ export default function LectureCard({ lecture, onDelete }: LectureCardProps) {
         });
     };
 
-    const thumbnailSrc = lecture.thumbnailBase64
-        ? `data:image/png;base64,${lecture.thumbnailBase64}`
-        : "/images/1.png";
+    const getThumbnailSrc = (): string => {
+        if (lecture.thumbnailBase64) {
+            return `data:image/png;base64,${lecture.thumbnailBase64}`;
+        }
+
+        // CSR 환경에서만 localStorage 접근
+        if (typeof window !== "undefined") {
+            const type = localStorage.getItem(`lecture-type-${lecture.lectureId}`);
+            if (type === "youtube") return "/images/2.png";
+            if (type === "audio") return "/images/3.png";
+        }
+
+        return "/images/1.png"; // 기본 fallback
+    };
+
+    const thumbnailSrc = getThumbnailSrc();
+
 
     return (
         <Link href={`/summary/${lecture.lectureId}`}>

--- a/frontend/src/components/lecture-list.tsx
+++ b/frontend/src/components/lecture-list.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import Link from "next/link"
+import Image from "next/image";
+import { X } from "lucide-react"
+
+interface Lecture {
+  lectureId: number
+  customTitle: string
+  duration: number;
+  thumbnailBase64?: string;
+  enrolledAt?: string
+}
+
+interface LectureListProps {
+  lectures: Lecture[]
+  onDelete?: (lectureId: number) => void
+}
+
+const formatDate = (isoString: string): string => {
+  const date = new Date(isoString)
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  })
+}
+
+const formatDuration = (duration: number): string => {
+  const mins = Math.floor(duration / 60)
+  const secs = duration % 60
+  return `${mins}:${secs.toString().padStart(2, "0")}`
+}
+
+export default function LectureList({ lectures, onDelete }: LectureListProps) {
+    const getThumbnailSrc = (lecture: Lecture): string => {
+        if (lecture.thumbnailBase64) {
+            return `data:image/png;base64,${lecture.thumbnailBase64}`
+        }
+
+        if (typeof window !== "undefined") {
+            const type = localStorage.getItem(`lecture-type-${lecture.lectureId}`)
+            if (type === "youtube") return "/images/2.png"
+            if (type === "audio") return "/images/1.png"
+        }
+        return "/images/1.png"
+        }
+  return (
+    <div className="space-y-2">
+      {lectures.map((lecture) => {
+        const thumbnailSrc = getThumbnailSrc(lecture)
+
+        return (
+          <div
+            key={lecture.lectureId}
+            className="flex gap-4 items-center border rounded-md p-4 hover:bg-muted transition relative"
+          >
+            <Link
+              href={`/summary/${lecture.lectureId}`}
+              className="flex gap-4 items-center w-full"
+            >
+              <div className="w-32 h-20 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+                <Image
+                  src={thumbnailSrc}
+                  alt="썸네일"
+                  width={128}
+                  height={80}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium line-clamp-1">{lecture.customTitle}</p>
+                <div className="text-sm text-muted-foreground flex gap-4">
+                  <span>{formatDuration(lecture.duration)}</span>
+                  <span>{lecture.enrolledAt ? formatDate(lecture.enrolledAt) : "-"}</span>
+                </div>
+              </div>
+            </Link>
+            {onDelete && (
+              <button
+                onClick={() => onDelete(lecture.lectureId)}
+                className="absolute top-2 right-2 text-muted-foreground hover:text-destructive"
+              >
+                <X size={18} />
+              </button>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to switch between card and list views for lecture summaries on the dashboard, with dedicated buttons for toggling display modes.
  - Introduced a new lecture list view, displaying lectures with thumbnails, titles, durations, and enrollment dates, along with optional delete functionality.

- **Enhancements**
  - Improved user feedback by replacing alert pop-ups with toast notifications on the account edit page.
  - Enhanced the upload experience by displaying a progress bar and status messages during YouTube uploads.
  - Lecture types for uploads are now tracked in localStorage for better image fallback handling.

- **UI/UX Improvements**
  - Updated labels and headings for clarity and consistency (e.g., changed "동영상" to "강의", and "녹음 파일" to "음성 파일").
  - Refined thumbnail image selection logic for lectures based on their type and upload source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->