### PR TITLE
feat: lecture 관련 DTO에 yotubeUrl 추가

### DIFF
--- a/backend/src/main/java/com/ktnu/AiLectureSummary/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                                 "/api/password/verify","/api/password/reset", // 비밀번호 재설정 관련
                                 "/health", "/swagger-ui/**","/v3/api-docs/**", // swagger & health check
                                 "/swagger-ui.html").permitAll() // 로그인, 회원가입, 스웨거, 헬스체크, 비밀번호 변경 등 인증없이 접근 허용
-//                        .requestMatchers(HttpMethod.GET, "/api/Lecture/**").permitAll()
+//                        .requestMatchers(HttpMethod.GET, "/api/lectures/**").permitAll()
                         .anyRequest().authenticated() // 그 외 요청은 인증 필요
                 )
                 .exceptionHandling(ex -> ex

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/LectureController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/LectureController.java
@@ -18,13 +18,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/lecture")
+@RequestMapping("/api/lectures")
 public class LectureController {
 
     private final LectureUploadService lectureUploadService;
 
 
-    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/mediaFile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "업로드 영상 요약 생성", description = "업로드 된 영상을 Ai를 사용해 요약합니다.")
     public ResponseEntity<ApiResponse<LectureUploadResponse>> uploadLecture(
             @AuthenticationPrincipal CustomUserDetails user,
@@ -34,7 +34,7 @@ public class LectureController {
         return ResponseEntity.ok(ApiResponse.success("요약 생성 성공", data));
     }
 
-    @PostMapping("/youtubeSummary")
+    @PostMapping("/youtube")
     @Operation(summary = "유트브 영상 요약 생성", description = "유트브 영상을 자막기반으로 Ai를 사용해 요약합니다.")
     public ResponseEntity<ApiResponse<LectureUploadResponse>> uploadYoutubeLecture(
             @AuthenticationPrincipal CustomUserDetails user,

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/lecture/LectureUploadResponse.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/lecture/LectureUploadResponse.java
@@ -13,10 +13,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LectureUploadResponse {
     private long id;
-    private String title;
-    private String originalText;
-    private String aiSummary;
-    private long duration;
+//    private String title;
+//    private String originalText;
+//    private String aiSummary;
+//    private long duration;
 
 
 
@@ -24,10 +24,10 @@ public class LectureUploadResponse {
 
     return    LectureUploadResponse.builder()
                 .id(lecture.getId())
-                .title(lecture.getTitleByAi())
-                .originalText(lecture.getOriginalText())
-                .aiSummary(lecture.getAiSummary())
-                .duration(lecture.getDuration())
+//                .title(lecture.getTitleByAi())
+//                .originalText(lecture.getOriginalText())
+//                .aiSummary(lecture.getAiSummary())
+//                .duration(lecture.getDuration())
                 .build();
         }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/memberLecture/LectureDetailResponse.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/memberLecture/LectureDetailResponse.java
@@ -21,6 +21,7 @@ public class LectureDetailResponse {
     private long duration;
     private LocalDateTime enrolledAt;
     private String thumbnailBase64;
+    private String youtubeUrl;
 
     public static LectureDetailResponse from(MemberLecture memberLecture) {
         Lecture lecture = memberLecture.getLecture();
@@ -33,6 +34,7 @@ public class LectureDetailResponse {
                 .originalText(lecture.getOriginalText())
                 .memo(memberLecture.getMemo())
                 .enrolledAt(memberLecture.getEnrolledAt())
+                .youtubeUrl(lecture.getYoutubeUrl())
                 .thumbnailBase64(ThumbnailUtil.encodeBase64ThumbnailSafe(memberLecture.getLecture().getThumbnail()))
                 .build();
     }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/dto/memberLecture/MemberLectureListItemResponse.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/dto/memberLecture/MemberLectureListItemResponse.java
@@ -18,6 +18,7 @@ public class MemberLectureListItemResponse {
     private String customTitle;
     private Long duration;
     private LocalDateTime enrolledAt;
+    private String youtubeUrl;
     private String thumbnailBase64;
 
     public static List<MemberLectureListItemResponse> fromList(List<MemberLecture> memberLectures) {
@@ -28,6 +29,7 @@ public class MemberLectureListItemResponse {
                         memberLecture.getCustomTitle(),
                         memberLecture.getLecture().getDuration(),
                         memberLecture.getEnrolledAt(),
+                        memberLecture.getLecture().getYoutubeUrl(),
                         ThumbnailUtil.encodeBase64ThumbnailSafe(memberLecture.getLecture().getThumbnail())
                 ))
                 .toList();

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/LectureService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/LectureService.java
@@ -44,9 +44,9 @@ public class LectureService {
     public Lecture processLecture(MultipartFile file) {
         validateMediaFile(file);
 
-        // VideoHasing & DB에 중복되는 영상이 존재하는지 확인
-        String videoHash = generateMediaHash(file);
-        Optional<Lecture> optionalLecture = lectureRepository.findByHash(videoHash);
+        // MediaHasing & DB에 중복되는 영상이 존재하는지 확인
+        String mediaHash = generateMediaHash(file);
+        Optional<Lecture> optionalLecture = lectureRepository.findByHash(mediaHash);
 
         // 이미 존재하는 경우 바로 바로 반환
         if (optionalLecture.isPresent()) {
@@ -61,7 +61,7 @@ public class LectureService {
         byte[] thumbnailBytes = ThumbnailUtil.decodeBase64ThumbnailSafe(registerRequest.getThumbnail());
 
         // DB에 강의 내용 저장
-        return lectureRepository.save(Lecture.fromUploadedVideo(registerRequest, videoHash,thumbnailBytes));
+        return lectureRepository.save(Lecture.fromUploadedVideo(registerRequest, mediaHash,thumbnailBytes));
 
     }
 
@@ -127,9 +127,9 @@ public class LectureService {
     }
 
     /**
-     * 비디오 파일을 SHA-256 해시 알고리즘으로 해싱하여 고유 문자열을 생성한다.
+     * 미디어 파일(비디오/오디오)을 SHA-256 해시 알고리즘으로 해싱하여 고유 문자열을 생성한다.
      *
-     * @param file 해싱할 비디오 파일
+     * @param file 해싱할 미디어 파일
      * @return Base64로 인코딩된 해시 문자열
      * @throws RuntimeException 파일 읽기 실패 또는 해시 처리 실패 시
      */
@@ -154,7 +154,7 @@ public class LectureService {
             // 이진 데이터-> 문자열 형태의 해시값으로 리턴
             return Base64.getEncoder().encodeToString(hashBytes);
         } catch (IOException | NoSuchAlgorithmException e) {
-            throw new RuntimeException("비디오 해싱 실패", e);
+            throw new RuntimeException("미디어 해싱 실패", e);
         }
     }
 
@@ -174,6 +174,4 @@ public class LectureService {
             throw new InvalidVideoFileException("지원하지 않는 파일 형식입니다. 비디오 또는 오디오 파일만 업로드 가능합니다.");
         }
     }
-    // 비디오 삭제?
-
 }

--- a/frontend/src/components/UploadTabs.tsx
+++ b/frontend/src/components/UploadTabs.tsx
@@ -29,7 +29,7 @@ export default function UploadTabs() {
     if (!youtubeUrl.trim()) return;
 
     try {
-      const res = await fetch(`${API_BASE_URL}/api/lecture/youtubeSummary`, {
+      const res = await fetch(`${API_BASE_URL}/api/lectures/youtube`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -92,7 +92,7 @@ export default function UploadTabs() {
           }
         };
 
-        xhr.open("POST", `${API_BASE_URL}/api/lecture/upload`);
+        xhr.open("POST", `${API_BASE_URL}/api/lectures/mediaFile`);
         xhr.withCredentials = true;
         xhr.send(formData);
       });

--- a/frontend/src/components/video-uploader.tsx
+++ b/frontend/src/components/video-uploader.tsx
@@ -110,7 +110,7 @@ export default function VideoUploader() {
           }
         }
 
-        xhr.open('POST', `${API_BASE_URL}/api/lecture/upload`)
+        xhr.open('POST', `${API_BASE_URL}/api/lectures/mediaFile`)
         xhr.withCredentials = true
         xhr.send(formData)
       })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added YouTube URL information to lecture detail and lecture list responses.

- **Bug Fixes**
  - Updated API endpoint paths for lecture-related actions to use consistent naming (e.g., `/api/lectures/mediaFile`, `/api/lectures/youtube`).

- **Refactor**
  - Changed terminology from "video" to "media" throughout the backend to reflect support for both video and audio files.
  - Removed unused fields from lecture upload response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->