### PR TITLE
feat: 회원탈퇴 기능 추가

### DIFF
--- a/backend/src/main/java/com/ktnu/AiLectureSummary/application/LectureUploadApplicationService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/application/LectureUploadApplicationService.java
@@ -1,8 +1,11 @@
-package com.ktnu.AiLectureSummary.service;
+package com.ktnu.AiLectureSummary.application;
 
 import com.ktnu.AiLectureSummary.domain.Lecture;
 import com.ktnu.AiLectureSummary.dto.lecture.LectureUploadResponse;
 import com.ktnu.AiLectureSummary.security.CustomUserDetails;
+import com.ktnu.AiLectureSummary.service.LectureService;
+import com.ktnu.AiLectureSummary.service.MemberLectureService;
+import com.ktnu.AiLectureSummary.service.YoutubeLectureService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Service
 @Transactional
-public class LectureUploadService {
+public class LectureUploadApplicationService {
     private final LectureService lectureService;
     private final MemberLectureService memberLectureService;
     private final YoutubeLectureService youtubeLectureService;

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/application/MemberDeleteApplicationService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/application/MemberDeleteApplicationService.java
@@ -1,0 +1,37 @@
+package com.ktnu.AiLectureSummary.application;
+
+import com.ktnu.AiLectureSummary.service.MemberLectureService;
+import com.ktnu.AiLectureSummary.service.MemberProfileService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * 사용자의 탈퇴 요청을 처리하는 애플리케이션 서비스
+ * <p>
+ * 사용자와 강의들의 연관 관계를 모두 제거합니다.
+ * 사용자의 계정을 비활성화합니다.
+ * <p>
+ * 내부적으로 MemberLectureService MemberProfileService 조합하여
+ * 유스케이스 단위 로직을 처리합니다.
+ *
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberDeleteApplicationService {
+
+    private final MemberLectureService memberLectureService;
+    private final MemberProfileService memberProfileService;
+
+
+    public void deleteMember(Long memberId) {
+        // 강의 연관관계 제거
+        memberLectureService.deleteLecturesByMemberId(memberId);
+
+        // 회원 비활성화 처리
+        memberProfileService.deactivate(memberId);
+
+    }
+}

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/AuthController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    @Operation(summary = "로그인", description = "사용자 정보를 입력 받아 로그인 시도 성공시 jwt(httponly) 반환")
+    @Operation(summary = "로그인", description = "사용자 정보를 입력 받아 로그인 시도 성공시 jwt(accessToken, refreshToken) 반환")
     public ResponseEntity<ApiResponse<MemberLoginResponse>> login(@Valid @RequestBody MemberLoginRequest request, HttpServletResponse response) { // HttpServletResponse response는 응답 헤더, 쿠키를 직접 조작할수 있게 하기 위해 사용됨
         // 로그인 처리 시도 (memberAuthService에서 인증 처리 + JWT 발급)
         MemberLoginResponse result = memberAuthService.login(request);

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/controller/LectureController.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/controller/LectureController.java
@@ -5,7 +5,7 @@ import com.ktnu.AiLectureSummary.dto.ApiResponse;
 import com.ktnu.AiLectureSummary.dto.lecture.LectureUploadResponse;
 import com.ktnu.AiLectureSummary.dto.lecture.YoutubeLectureRequest;
 import com.ktnu.AiLectureSummary.security.CustomUserDetails;
-import com.ktnu.AiLectureSummary.service.LectureUploadService;
+import com.ktnu.AiLectureSummary.application.LectureUploadApplicationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -21,7 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/lectures")
 public class LectureController {
 
-    private final LectureUploadService lectureUploadService;
+    private final LectureUploadApplicationService lectureUploadApplicationService;
 
 
     @PostMapping(value = "/mediaFile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -30,7 +30,7 @@ public class LectureController {
             @AuthenticationPrincipal CustomUserDetails user,
             @Parameter(description = "요약할 영상 파일", required = true)
             @RequestPart("file") MultipartFile file) {
-        LectureUploadResponse data = lectureUploadService.uploadLecture(user, file);
+        LectureUploadResponse data = lectureUploadApplicationService.uploadLecture(user, file);
         return ResponseEntity.ok(ApiResponse.success("요약 생성 성공", data));
     }
 
@@ -41,7 +41,7 @@ public class LectureController {
             @Parameter(description = "요약할 영상 youtubeUrl", required = true)
             @Valid @RequestBody YoutubeLectureRequest request) {
         String url = request.getUrl();
-        LectureUploadResponse data = lectureUploadService.uploadYoutubeLecture(user, url);
+        LectureUploadResponse data = lectureUploadApplicationService.uploadYoutubeLecture(user, url);
         return ResponseEntity.ok(ApiResponse.success("요약 생성 성공", data));
     }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/domain/Member.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/domain/Member.java
@@ -107,5 +107,10 @@ public class Member {
     private Role role;
 
 
+    // 소프트 삭제(비활성화)
+    public void deactivate() {
+        this.active = false;
+    }
+
 
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/exception/AccountInactiveException.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/exception/AccountInactiveException.java
@@ -1,0 +1,9 @@
+package com.ktnu.AiLectureSummary.exception;
+
+public class AccountInactiveException extends RuntimeException {
+  public AccountInactiveException(String message) {
+    super(message);
+  }
+  public AccountInactiveException(String message, Throwable cause) {
+    super(message, cause);
+  }}

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/exception/GlobalExceptionHandler.java
@@ -165,4 +165,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of("VALIDATION_ERROR", errorMessage, HttpStatus.BAD_REQUEST.value(), request.getRequestURI()));
     }
+
+
+    /**
+     * 탈퇴한 계정으로 로그인 시도할 때 발생하는 예외 처리 핸들러
+     *
+     * @param e 탈퇴 계정 접근 시 발생한 예외 객체
+     * @param request request 요청 객체 (요청 URI 포함)
+     * @return 401 Unauthorized 응답과 상세 에러 메시지
+     */
+    @ExceptionHandler(AccountInactiveException.class)
+    public ResponseEntity<ErrorResponse> handleAccountInactiveException(AccountInactiveException e, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of("ACCOUNT_INACTIVE", e.getMessage(), HttpStatus.UNAUTHORIZED.value(), request.getRequestURI()));
+    }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/security/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.ktnu.AiLectureSummary.security;
 
 import com.ktnu.AiLectureSummary.domain.Member;
+import com.ktnu.AiLectureSummary.exception.AccountInactiveException;
 import com.ktnu.AiLectureSummary.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -28,6 +29,9 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+        if (!member.isActive()) {
+            throw new AccountInactiveException("탈퇴한 회원입니다.");
+        }
         return new CustomUserDetails(member);
     }
 
@@ -39,6 +43,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserById(Long userId) {
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다. ID=" + userId));
+        if (!member.isActive()) {
+            throw new AccountInactiveException("탈퇴한 회원입니다.");
+        }
+
         return new CustomUserDetails(member);
     }
 }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/security/JwtAuthenticationFilter.java
@@ -46,7 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 // 토큰에서 사용자 ID 추출
                 Long userId = jwtProvider.getUserIdFromAccessToken(token);
 
-                // 해당 ID로 사용자 정보 조회
+                // 해당 ID로 사용자 정보 조회 // 탈퇴 여부 검사 포함
                 CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserById(userId);
 
                 // 사용자 정보가 없는 경우 인증 실패 처리

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberAuthService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberAuthService.java
@@ -4,10 +4,7 @@ import com.ktnu.AiLectureSummary.config.JwtProperties;
 import com.ktnu.AiLectureSummary.domain.Member;
 import com.ktnu.AiLectureSummary.domain.Role;
 import com.ktnu.AiLectureSummary.dto.member.*;
-import com.ktnu.AiLectureSummary.exception.DuplicateLoginIdException;
-import com.ktnu.AiLectureSummary.exception.InvalidPasswordException;
-import com.ktnu.AiLectureSummary.exception.InvalidTokenException;
-import com.ktnu.AiLectureSummary.exception.MemberNotFoundException;
+import com.ktnu.AiLectureSummary.exception.*;
 import com.ktnu.AiLectureSummary.repository.MemberRepository;
 import com.ktnu.AiLectureSummary.security.JwtProvider;
 import com.ktnu.AiLectureSummary.util.CookieUtil;
@@ -48,7 +45,7 @@ public class MemberAuthService {
 
         // 중복된 이메일 체크
         if (memberRepository.existsByEmail(email)) {
-            throw new DuplicateLoginIdException("이미 사용 중인 이메일입니다");
+            throw new DuplicateLoginIdException("이미 사용 중인 이메일입니다.");
         }
 
         // 멤버 생성
@@ -79,6 +76,12 @@ public class MemberAuthService {
 
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException("이메일이 존재하지 않습니다."));
+
+        // 탈퇴한 회원 차단
+        if (!member.isActive()){
+            throw new AccountInactiveException("탈퇴한 회원입니다.");
+        }
+
         if (!passwordEncoder.matches(password, member.getPassword())) {
             throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
         }

--- a/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberProfileService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/service/MemberProfileService.java
@@ -5,6 +5,7 @@ import com.ktnu.AiLectureSummary.dto.member.MemberEditRequest;
 import com.ktnu.AiLectureSummary.dto.member.MemberEditResponse;
 import com.ktnu.AiLectureSummary.exception.MemberNotFoundException;
 import com.ktnu.AiLectureSummary.exception.NoProfileChangesException;
+import com.ktnu.AiLectureSummary.repository.MemberLectureRepository;
 import com.ktnu.AiLectureSummary.repository.MemberRepository;
 import com.ktnu.AiLectureSummary.security.CustomUserDetails;
 import com.ktnu.AiLectureSummary.security.JwtProvider;
@@ -20,6 +21,8 @@ public class MemberProfileService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final MemberLectureRepository memberLectureRepository;
+    private final MemberLectureService memberLectureService;
 
     /**
      * 사용자 정보를 수정합니다. (수정 가능한 정보: 이름, 비밀번호)
@@ -62,5 +65,13 @@ public class MemberProfileService {
                 .email(member.getEmail())
                 .token(token)
                 .build();
+    }
+
+    public void deactivate(Long id) {
+        // 로그인한 사용자의 정보 찾기
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new MemberNotFoundException("존재 하지 않는 회원입니다."));
+        // 회원 탈퇴
+        member.deactivate();
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
 


### PR DESCRIPTION
	•	로그인 시 active 필드 검사 → 탈퇴한 회원은 로그인 불가
	•	JWT 인증 필터에서 active 상태 확인 → 유효한 토큰이 있어도 탈퇴 회원은 인증 차단
	•	서비스 내부 로직에서는 active 상태 별도 검사 생략
	•	회원 탈퇴 API 구현 완료
	•	회원 비활성화 시 연관 강의(회원 소유 강의 기록) 모두 제거, 참조 강의 없을 경우 해당 강의 자체도 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to delete (deactivate) their accounts via a new endpoint in the profile section.
  - Implemented soft deletion for user accounts, ensuring deactivated users cannot log in.
  - Introduced specific error handling and messaging for login attempts by deactivated accounts.

- **Improvements**
  - Enhanced login documentation to clarify that both access and refresh tokens are returned upon successful login.
  - Improved lecture association cleanup when a user deletes their account.

- **Bug Fixes**
  - Ensured proper cleanup of user-related lectures when an account is deleted.

- **Chores**
  - Updated database schema generation to recreate the schema on each application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->