### PR TITLE
test: 계정 정보 수정시 기존 비밀번호 확인 로직 추가

### DIFF
--- a/backend/src/main/java/com/ktnu/AiLectureSummary/application/service/PasswordResetService.java
+++ b/backend/src/main/java/com/ktnu/AiLectureSummary/application/service/PasswordResetService.java
@@ -4,6 +4,7 @@ import com.ktnu.AiLectureSummary.domain.Member;
 import com.ktnu.AiLectureSummary.application.dto.member.request.MemberResetPasswordRequest;
 import com.ktnu.AiLectureSummary.application.dto.member.request.MemberVerifyRequest;
 import com.ktnu.AiLectureSummary.application.dto.member.response.MemberPasswordResetTokenResponse;
+import com.ktnu.AiLectureSummary.global.exception.AccountInactiveException;
 import com.ktnu.AiLectureSummary.global.exception.InvalidTokenException;
 import com.ktnu.AiLectureSummary.global.exception.MemberNotFoundException;
 import com.ktnu.AiLectureSummary.repository.MemberRepository;
@@ -39,6 +40,11 @@ public class PasswordResetService {
 
         Member member = memberRepository.findByUsernameAndEmail(name, email)
                 .orElseThrow(() -> new MemberNotFoundException("존재하지 않는 사용자 정보입니다."));
+
+        // 탈퇴한 회원인지 검사
+        if (!member.isActive()) {
+            throw new AccountInactiveException("탈퇴한 회원입니다.");
+        }
 
         // 이름과 이메일이 일치하는 사용자가 존재함을 확인했으므로, 임시 토큰을 발급 (실제 서비스의 경우 이메일로 토큰 전송)
         String token = UUID.randomUUID().toString(); // 유니버설 고유 식별자 생성 // TODO 예측이 가능한 구조 SecureRandom로 리팩터링

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Password reset now checks if the account is active before allowing a reset, providing clearer feedback for inactive accounts.

- **Chores**
  - Updated database schema management to prevent data loss by switching to incremental updates instead of recreating tables on each start.

- **Tests**
  - Enhanced profile editing tests to verify current password before allowing changes, including new tests for incorrect password scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->